### PR TITLE
Added the full --help for the app.

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -14,6 +14,7 @@ pub enum Format {
     Webp,
     Png,
     Jpg,
+    Avif,
 }
 
 /// Auto-naming strategy when no output path given.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -11,10 +11,10 @@ pub enum Command {
 /// Output image format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Format {
-    Webp,
-    Png,
-    Jpg,
-    Avif,
+    AVIF,
+    JPEG,
+    PNG,
+    WEBP,
 }
 
 /// Auto-naming strategy when no output path given.

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -12,7 +12,7 @@ COMMANDS:
 GLOBAL OPTIONS:
   -o, --output <PATH>
           Save to an exact file path.
-          Format is inferred from the file extension (.webp, .png, .jpg, .jpeg, .qoi, etc. if supported).
+          Format is inferred from the file extension (.webp, .png, .jpg, .jpeg, and .avif).
           When --output is used, format flags like --webp/--png/--jpg are not allowed.
           If the file already exists, a new file will be added with the current timestamp before the extension.
 
@@ -41,10 +41,10 @@ GLOBAL OPTIONS:
       --naming <MODE> | --naming
           Auto-generated file naming strategy when --output is not provided.
           Possible values:
-            datetime      "Screenshot - 2026-02-12 11_22_33.webp" (default)
+            timestamp      "Screenshot - 2026-02-12 11_22_33.webp" (default)
             incremental   "Screenshot - 0001.webp", "Screenshot - 0002.webp", ...
             hash          "Screenshot - a1b2c3d4.webp" (short content hash)
-          [default: datetime]
+          [default: timestamp]
 
       --dir <DIR>
           Output directory for auto-generated filenames (when --output is not provided).
@@ -70,10 +70,10 @@ FORMAT SHORTCUTS (when NOT using --output):
     --jpg    Save as .jpg
 
 NAMING EXAMPLES (auto-generated names):
-  Default (datetime):
+  Default (timestamp):
     Screenshot - 2026-02-12 11_22_33.webp
 
-  Custom prefix + datetime:
+  Custom prefix + timestamp:
     --prefix "RimWorld"
     => RimWorld - 2026-02-12 11_22_33.webp
 

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,0 +1,117 @@
+/// Show full help text to stdout.
+pub fn show_help() {
+    println!(r#"gnome-screenshotter — GNOME/Wayland-first CLI screenshots (WebP by default)
+
+USAGE:
+  gnome-screenshotter [OPTIONS] <COMMAND> [COMMAND OPTIONS]
+
+COMMANDS:
+  full        Capture the full screen
+  box         Capture a rectangular region using the mouse (interactive portal selection)
+
+GLOBAL OPTIONS:
+  -o, --output <PATH>
+          Save to an exact file path.
+          Format is inferred from the file extension (.webp, .png, .jpg, .jpeg, .qoi, etc. if supported).
+          When --output is used, format flags like --webp/--png/--jpg are not allowed.
+          If the file already exists, a new file will be added with the current timestamp before the extension.
+
+      --webp
+          Save using WebP format (default when --output is not provided)
+
+      --png
+          Save using PNG format (shortcut; no need to type -o shot.png)
+
+      --jpg | --jpeg
+          Save using JPEG format (shortcut; no need to type -o shot.jpg)
+
+      --quality <0-100>
+          Output quality for lossy formats (currently JPEG/WebP lossy mode).
+          Ignored for PNG and lossless WebP.
+          [default: 90]
+
+      --lossless
+          Use lossless encoding when supported (e.g. WebP).
+          Ignored for formats that do not support lossless mode.
+
+      --prefix <TEXT>
+          File name prefix used when --output is not provided.
+          [default: "Screenshot"]
+
+      --naming <MODE> | --naming
+          Auto-generated file naming strategy when --output is not provided.
+          Possible values:
+            datetime      "Screenshot - 2026-02-12 11_22_33.webp" (default)
+            incremental   "Screenshot - 0001.webp", "Screenshot - 0002.webp", ...
+            hash          "Screenshot - a1b2c3d4.webp" (short content hash)
+          [default: datetime]
+
+      --dir <DIR>
+          Output directory for auto-generated filenames (when --output is not provided).
+          If omitted, uses the current directory (or platform default if configured).
+
+      --print-path
+          Print the final saved file path to stdout on success (script-friendly)
+
+  -q, --quiet
+          Suppress non-error output
+
+  -h, --help
+          Print help
+
+  -V, --version
+          Print version
+
+FORMAT SHORTCUTS (when NOT using --output):
+  By default, screenshots are saved as WebP.
+  Use one of these for quick format selection:
+    --webp   Save as .webp (default)
+    --png    Save as .png
+    --jpg    Save as .jpg
+
+NAMING EXAMPLES (auto-generated names):
+  Default (datetime):
+    Screenshot - 2026-02-12 11_22_33.webp
+
+  Custom prefix + datetime:
+    --prefix "RimWorld"
+    => RimWorld - 2026-02-12 11_22_33.webp
+
+  Incremental:
+    --naming incremental
+    => Screenshot - 0001.webp, Screenshot - 0002.webp, ...
+
+  Short file hash:
+    --naming hash
+    => Screenshot - a1b2c3d4.webp
+
+IMPORTANT RULES:
+  • help is not a subcommand; use --help
+  • If -o/--output is used, format is determined by the file extension
+  • If -o/--output is used, --webp/--png/--jpg/--jpeg are invalid
+  • If no format is specified and no -o is given, WebP is used by default
+
+EXAMPLES:
+  gnome-screenshotter full
+      Save full screenshot as:
+      "Screenshot - YYYY-MM-DD HH_MM_SS.webp"
+
+  gnome-screenshotter box
+      Interactive rectangle capture, saved as WebP by default
+
+  gnome-screenshotter box --png
+      Interactive rectangle capture, saved as PNG
+
+  gnome-screenshotter full --jpg --quality 85
+      Full screenshot as JPEG quality 85
+
+  gnome-screenshotter full --prefix "RimWorld" --naming incremental
+      Saves as "RimWorld - 0001.webp", etc.
+
+  gnome-screenshotter box --naming hash --print-path
+      Saves as "Screenshot - <hash>.webp" and prints the path
+
+  gnome-screenshotter full -o ~/Pictures/shot.png
+      Explicit path; format inferred from ".png"
+"#);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@
 //! No clap. Uses lexopt for token scanning only.
 
 mod config;
+mod help;
 mod raw;
 mod validate;
 
@@ -18,40 +19,9 @@ pub fn parse() -> Result<ParseOutcome, String> {
     validate::normalize(raw)
 }
 
-/// Show help text to stdout.
-pub fn show_help() {
-    println!(
-        r#"gnome-screenshotter {}
-
-Take screenshots on GNOME/Wayland using xdg-desktop-portal.
-
-USAGE:
-    gnome-screenshotter [OPTIONS] <COMMAND>
-
-COMMANDS:
-    full    Take a full-screen screenshot
-    box     Take an interactive rectangular screenshot
-
-OPTIONS:
-    -h, --help              Print help
-    -V, --version           Print version
-    -o, --output <PATH>     Save to specific path (infers format from extension)
-    --webp                  Use WebP format (default, only without -o)
-    --png                   Use PNG format (only without -o)
-    --jpg                   Use JPEG format (only without -o)
-    --naming <MODE>         Naming mode for auto filenames: timestamp, incremental, hash
-
-RULES:
-    - Default format is WebP when no -o is given
-    - --webp, --png, --jpg are mutually exclusive
-    - --webp, --png, --jpg are invalid when -o is used
-    - Filenames never overwrite; collisions append .1, .2, etc. before extension
-"#,
-        env!("CARGO_PKG_VERSION")
-    );
-}
-
 /// Show version to stdout.
 pub fn show_version() {
     println!("gnome-screenshotter {}", env!("CARGO_PKG_VERSION"));
 }
+
+pub use help::show_help;

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -22,8 +22,21 @@ pub fn normalize(raw: RawArgs) -> Result<ParseOutcome, String> {
         return Ok(ParseOutcome::ShowVersion);
     }
 
+    // No command and no flags: show help
+    if raw.command.is_none()
+        && !raw.webp
+        && !raw.png
+        && !raw.jpg
+        && raw.naming.is_none()
+        && raw.output.is_none()
+    {
+        return Ok(ParseOutcome::ShowHelp);
+    }
+
     // Require exactly one command
-    let cmd_str = raw.command.ok_or_else(|| "Missing command: use 'full' or 'box'".to_string())?;
+    let cmd_str = raw
+        .command
+        .ok_or_else(|| "Missing command: use 'full' or 'box'".to_string())?;
     let command = match cmd_str.as_str() {
         "full" => Command::Full,
         "box" => Command::Box,
@@ -34,7 +47,9 @@ pub fn normalize(raw: RawArgs) -> Result<ParseOutcome, String> {
     let format_flags = [raw.webp, raw.png, raw.jpg];
     let format_flag_count = format_flags.iter().filter(|&&b| b).count();
     if format_flag_count > 1 {
-        return Err("Conflicting format flags: use at most one of --webp, --png, --jpg".to_string());
+        return Err(
+            "Conflicting format flags: use at most one of --webp, --png, --jpg".to_string(),
+        );
     }
 
     // Naming mode parsing
@@ -42,7 +57,12 @@ pub fn normalize(raw: RawArgs) -> Result<ParseOutcome, String> {
         None | Some("timestamp") => NamingMode::Timestamp,
         Some("incremental") => NamingMode::Incremental,
         Some("hash") => NamingMode::Hash,
-        Some(other) => return Err(format!("Invalid --naming mode: '{}'. Use: timestamp, incremental, hash", other)),
+        Some(other) => {
+            return Err(format!(
+                "Invalid --naming mode: '{}'. Use: timestamp, incremental, hash",
+                other
+            ))
+        }
     };
 
     // Determine output path and format
@@ -50,10 +70,16 @@ pub fn normalize(raw: RawArgs) -> Result<ParseOutcome, String> {
         Some(path_str) => {
             // With -o: format flags are illegal; infer from extension
             if format_flag_count > 0 {
-                return Err("Format flags (--webp, --png, --jpg) cannot be used with --output".to_string());
+                return Err(
+                    "Format flags (--webp, --png, --jpg) cannot be used with --output".to_string(),
+                );
             }
             let path = std::path::PathBuf::from(path_str);
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_ascii_lowercase();
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("")
+                .to_ascii_lowercase();
             let inferred = match ext.as_str() {
                 "png" => Format::Png,
                 "jpg" | "jpeg" => Format::Jpg,

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -81,10 +81,10 @@ pub fn normalize(raw: RawArgs) -> Result<ParseOutcome, String> {
                 .unwrap_or("")
                 .to_ascii_lowercase();
             let inferred = match ext.as_str() {
-                "png" => Format::Png,
-                "jpg" | "jpeg" => Format::Jpg,
-                "webp" => Format::Webp,
-                _ => Format::Webp, // default when extension unrecognized
+                'avif'         => Format::AVIF,
+                "png"          => Format::PNG,
+                "jpg" | "jpeg" => Format::JPEG,
+                "webp"         => Format::WEBP,
             };
             (Some(path), inferred)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,20 +7,20 @@ mod error;
 use cli::{show_help, show_version, ParseOutcome};
 
 fn main() {
-    match cli::parse() {
-        Ok(ParseOutcome::ShowHelp) => {
-            show_help();
-        }
-        Ok(ParseOutcome::ShowVersion) => {
-            show_version();
-        }
-        Ok(ParseOutcome::Run(config)) => {
-            println!("Running with config: {:?}", config);
-            // TODO: dispatch to capture module
-        }
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            std::process::exit(1);
-        }
-    }
+   match cli::parse() {
+       Ok(ParseOutcome::ShowHelp) => {
+           show_help();
+       }
+       Ok(ParseOutcome::ShowVersion) => {
+           show_version();
+       }
+       Ok(ParseOutcome::Run(config)) => {
+           println!("Running with config: {:?}", config);
+           // TODO: dispatch to capture module
+       }
+       Err(e) => {
+           eprintln!("Error: {}", e);
+           std::process::exit(1);
+       }
+   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,20 +7,20 @@ mod error;
 use cli::{show_help, show_version, ParseOutcome};
 
 fn main() {
-   match cli::parse() {
-       Ok(ParseOutcome::ShowHelp) => {
-           show_help();
-       }
-       Ok(ParseOutcome::ShowVersion) => {
-           show_version();
-       }
-       Ok(ParseOutcome::Run(config)) => {
-           println!("Running with config: {:?}", config);
-           // TODO: dispatch to capture module
-       }
-       Err(e) => {
-           eprintln!("Error: {}", e);
-           std::process::exit(1);
-       }
-   }
+    match cli::parse() {
+        Ok(ParseOutcome::ShowHelp) => {
+            show_help();
+        }
+        Ok(ParseOutcome::ShowVersion) => {
+            show_version();
+        }
+        Ok(ParseOutcome::Run(config)) => {
+            println!("Running with config: {:?}", config);
+            // TODO: dispatch to capture module
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
## **User description**
Output:

```
gnome-screenshotter — GNOME/Wayland-first CLI screenshots (WebP by default)

USAGE:
  gnome-screenshotter [OPTIONS] <COMMAND> [COMMAND OPTIONS]

COMMANDS:
  full        Capture the full screen
  box         Capture a rectangular region using the mouse (interactive portal selection)

GLOBAL OPTIONS:
  -o, --output <PATH>
          Save to an exact file path.
          Format is inferred from the file extension (.webp, .png, .jpg, .jpeg, .qoi, etc. if supported).
          When --output is used, format flags like --webp/--png/--jpg are not allowed.
          If the file already exists, a new file will be added with the current timestamp before the extension.

      --webp
          Save using WebP format (default when --output is not provided)

      --png
          Save using PNG format (shortcut; no need to type -o shot.png)

      --jpg | --jpeg
          Save using JPEG format (shortcut; no need to type -o shot.jpg)

      --quality <0-100>
          Output quality for lossy formats (currently JPEG/WebP lossy mode).
          Ignored for PNG and lossless WebP.
          [default: 90]

      --lossless
          Use lossless encoding when supported (e.g. WebP).
          Ignored for formats that do not support lossless mode.

      --prefix <TEXT>
          File name prefix used when --output is not provided.
          [default: "Screenshot"]

      --naming <MODE> | --naming
          Auto-generated file naming strategy when --output is not provided.
          Possible values:
            datetime      "Screenshot - 2026-02-12 11_22_33.webp" (default)
            incremental   "Screenshot - 0001.webp", "Screenshot - 0002.webp", ...
            hash          "Screenshot - a1b2c3d4.webp" (short content hash)
          [default: datetime]

      --dir <DIR>
          Output directory for auto-generated filenames (when --output is not provided).
          If omitted, uses the current directory (or platform default if configured).

      --print-path
          Print the final saved file path to stdout on success (script-friendly)

  -q, --quiet
          Suppress non-error output

  -h, --help
          Print help

  -V, --version
          Print version

FORMAT SHORTCUTS (when NOT using --output):
  By default, screenshots are saved as WebP.
  Use one of these for quick format selection:
    --webp   Save as .webp (default)
    --png    Save as .png
    --jpg    Save as .jpg

NAMING EXAMPLES (auto-generated names):
  Default (datetime):
    Screenshot - 2026-02-12 11_22_33.webp

  Custom prefix + datetime:
    --prefix "RimWorld"
    => RimWorld - 2026-02-12 11_22_33.webp

  Incremental:
    --naming incremental
    => Screenshot - 0001.webp, Screenshot - 0002.webp, ...

  Short file hash:
    --naming hash
    => Screenshot - a1b2c3d4.webp

IMPORTANT RULES:
  • help is not a subcommand; use --help
  • If -o/--output is used, format is determined by the file extension
  • If -o/--output is used, --webp/--png/--jpg/--jpeg are invalid
  • If no format is specified and no -o is given, WebP is used by default

EXAMPLES:
  gnome-screenshotter full
      Save full screenshot as:
      "Screenshot - YYYY-MM-DD HH_MM_SS.webp"

  gnome-screenshotter box
      Interactive rectangle capture, saved as WebP by default

  gnome-screenshotter box --png
      Interactive rectangle capture, saved as PNG

  gnome-screenshotter full --jpg --quality 85
      Full screenshot as JPEG quality 85

  gnome-screenshotter full --prefix "RimWorld" --naming incremental
      Saves as "RimWorld - 0001.webp", etc.

  gnome-screenshotter box --naming hash --print-path
      Saves as "Screenshot - <hash>.webp" and prints the path

  gnome-screenshotter full -o ~/Pictures/shot.png
      Explicit path; format inferred from ".png"
```

Fixes #1.


___

## **CodeAnt-AI Description**
Show full, detailed help by default and add AVIF + extra help options

### What Changed
- Running the tool with no arguments now prints the full help text instead of doing nothing
- The help output was expanded with detailed usage, examples, and new options: --dir, --print-path, --quality, --lossless, and clearer rules for format selection
- AVIF was added to the documented list of supported output extensions; help clarifies how format is chosen when using --output
- Help printing was moved to a dedicated module and the CLI now explicitly triggers help when no command or flags are provided

### Impact
`✅ Shorter time to discover commands and options`
`✅ Clearer format selection and output path behavior`
`✅ Easier scripting with --print-path and explicit quality/lossless controls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
